### PR TITLE
griffin: Address additional mods_camd denials

### DIFF
--- a/sepolicy/device.te
+++ b/sepolicy/device.te
@@ -5,4 +5,5 @@ type hob_block_device, dev_type;
 type hw_block_device, dev_type;
 type laser_device, dev_type;
 type logs_block_device, dev_type;
+type mods_camd_device, dev_type;
 type utags_block_device, dev_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -66,6 +66,7 @@
 /data/gbfirmware(/.*)?                               u:object_r:gbfirmware_file:s0
 /dev/gbraw[0-9]*                               u:object_r:greybus_raw_device:s0
 
+/dev/mot_camera_ext0                                   u:object_r:mods_camd_device:s0
 /sys/devices/virtual/video4linux/video([0-9])+/name                               u:object_r:sysfs_mods_camd:s0
 /sys/devices/soc/(.+)hsusb(.+)/uevent                               u:object_r:sysfs_mods_camd:s0
 /sys/devices/soc/(.+)ssusb/power_supply/usb/type                               u:object_r:sysfs_mods_camd:s0

--- a/sepolicy/mods_camd.te
+++ b/sepolicy/mods_camd.te
@@ -8,4 +8,7 @@ allow mods_camd video_device:chr_file rw_file_perms;
 allow mods_camd self:netlink_kobject_uevent_socket { bind create read setopt };
 allow mods_camd sysfs_mods_camd:file rw_file_perms;
 allow mods_camd sysfs_mods_camd:dir rw_dir_perms;
+allow mods_camd sysfs:file { getattr read write };
+allow mods_camd sysfs:file { getattr open read write };
 
+allow mods_camd mods_camd_device:chr_file {getattr ioctl open read write };

--- a/sepolicy/ueventd.te
+++ b/sepolicy/ueventd.te
@@ -1,9 +1,10 @@
 allow ueventd device:chr_file { relabelfrom relabelto };
 allow ueventd input_device:chr_file { relabelfrom relabelto };
-allow ueventd video_device:chr_file { relabelfrom relabelto };
+allow ueventd mods_camd_device:chr_file { relabelfrom relabelto };
 allow ueventd sysfs_greybus:file { open write };
 allow ueventd sysfs_mmi_touch:file w_file_perms;
 allow ueventd sysfs_mmi_touch:dir search;
 allow ueventd self:netlink_kobject_uevent_socket { read };
 allow ueventd sysfs_mods_camd:file rw_file_perms;
 allow ueventd sysfs_mods_camd:dir rw_dir_perms;
+allow ueventd video_device:chr_file { relabelfrom relabelto };


### PR DESCRIPTION
Change-Id: Ibf226ff706bdef21d0479ae5a719221a001db95c

I have the camera mod here.  This still doesn't fix it, obviously.  Cameraserver just crashes constantly now.  https://pbot.rmdir.de/63UylSDXY8aUJrtgODbXdw

However, this does address all of the denies.  Up to you if you want to merge as is.  I just thought I'd at least push these changes up for now.